### PR TITLE
Address Ember.ajax PR Issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "**/.*"
   ],
   "dependencies": {
-    "ember": "~1.2.0"
+    "ember": ">=1.2 <2"
   },
   "devDependencies": {
     "sinon": "http://sinonjs.org/releases/sinon-1.7.3.js"

--- a/main.js
+++ b/main.js
@@ -76,8 +76,8 @@
       if (fixture) {
         return Ember.run(null, resolve, fixture);
       }
-      settings.success = makeSuccess(resolve, reject);
-      settings.error = makeError(resolve, reject);
+      settings.success = makeSuccess(resolve);
+      settings.error = makeError(reject);
       Ember.$.ajax(settings);
     }, 'ic-ajax: ' + (settings.type || 'GET') + ' to ' + settings.url);
   };
@@ -100,7 +100,7 @@
     return settings;
   }
 
-  function makeSuccess(resolve, reject) {
+  function makeSuccess(resolve) {
     return function(response, textStatus, jqXHR) {
       Ember.run(null, resolve, {
         response: response,
@@ -110,7 +110,7 @@
     }
   }
 
-  function makeError(resolve, reject) {
+  function makeError(reject) {
     return function(jqXHR, textStatus, errorThrown) {
       Ember.run(null, reject, {
         jqXHR: jqXHR,

--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@
    * and it resolves only the response (no access to jqXHR or textStatus).
    */
 
-  var ajax = function() {
+  var ajax = function ajax() {
     return ajax.raw.apply(null, arguments).then(function(result) {
       return result.response;
     });
@@ -34,7 +34,7 @@
    * jqXHR}`, useful if you need access to the jqXHR object for headers, etc.
    */
 
-  ajax.raw = function() {
+  ajax.raw = function ajaxRaw() {
     return makePromise(parseArgs.apply(null, arguments));
   };
 

--- a/main.js
+++ b/main.js
@@ -95,7 +95,7 @@
       settings.url = arguments[0];
     }
     if (settings.success || settings.error) {
-      throw new Error("ajax should use promises, received 'success' or 'error' callback");
+      throw new Ember.Error("ajax should use promises, received 'success' or 'error' callback");
     }
     return settings;
   }

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@
   var ajax = function ajax() {
     return ajax.raw.apply(null, arguments).then(function(result) {
       return result.response;
-    });
+    }, null, 'ic-ajax: unwrap raw ajax response');
   };
 
   /*
@@ -79,7 +79,7 @@
       settings.success = makeSuccess(resolve, reject);
       settings.error = makeError(resolve, reject);
       Ember.$.ajax(settings);
-    });
+    }, 'ic-ajax: ' + (settings.type || 'GET') + ' to ' + settings.url);
   };
 
   function parseArgs() {

--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@
    * and it resolves only the response (no access to jqXHR or textStatus).
    */
 
-  var ajax = function ajax() {
+  function ajax() {
     return ajax.raw.apply(null, arguments).then(function(result) {
       return result.response;
     }, null, 'ic-ajax: unwrap raw ajax response');

--- a/test.js
+++ b/test.js
@@ -73,6 +73,22 @@ test('throws if success or error callbacks are used', function() {
   });
 });
 
+if (parseFloat(Ember.VERSION) >= 1.3) {
+  function promiseLabelOf(promise) { return promise._label; }
+
+  test('labels the promise', function() {
+    var promise = ic.ajax('/foo');
+
+    equal(promiseLabelOf(promise), 'ic-ajax: unwrap raw ajax response', 'promise is labeled');
+  });
+
+  test('labels the promise', function() {
+    var promise = ic.ajax.raw('/foo');
+
+    equal(promiseLabelOf(promise), 'ic-ajax: GET to /foo', 'promise is labeled');
+  });
+}
+
 function fakeServer(method, url, response) {
   var server = sinon.fakeServer.create();
   var data = {foo: 'bar'};


### PR DESCRIPTION
Addresses the following issues brought up in https://github.com/emberjs/ember.js/pull/4148:
- Label anonymous functions.
- Label promises.
- Only pass resolve or reject as needed.
- Throw an instance of Ember.Error (to allow future customizability).

This also updates the Ember version in `bower.json` to allow `>=1.2` and `<2` (it was previously locked to 1.2.x).
