### PR TITLE
Allow fixtures that simulate an error response

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,7 +74,11 @@
     return new Ember.RSVP.Promise(function(resolve, reject) {
       var fixture = ajax.lookupFixture(settings.url);
       if (fixture) {
-        return Ember.run(null, resolve, fixture);
+        if (fixture.textStatus === 'success') {
+          return Ember.run(null, resolve, fixture);
+        } else {
+          return Ember.run(null, reject, fixture);
+        }
       }
       settings.success = makeSuccess(resolve);
       settings.error = makeError(reject);

--- a/test.js
+++ b/test.js
@@ -17,6 +17,19 @@ asyncTest('pulls from fixtures', function() {
   });
 });
 
+asyncTest('rejects the promise when the textStatus of the fixture is not success', function() {
+  ic.ajax.defineFixture('/post', {
+    errorThrown: 'Unprocessable Entity',
+    textStatus: 'error',
+    jqXHR: {}
+  });
+
+  start();
+  ic.ajax.raw('/post').then(null, function(reason) {
+    deepEqual(reason, ic.ajax.lookupFixture('/post'));
+  });
+});
+
 asyncTest('resolves the response only when not using raw', function() {
   ic.ajax.defineFixture('/get', {
     response: { foo: 'bar' },


### PR DESCRIPTION
Currently all fixtures will be resolved and thus mean success. This does not allow testing scenarios for error requests from the backend.

This commit fixes that.
