### PR TITLE
Deep Copy fixtures. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ ajax.raw('/foo').then(function(result) {
 Simplified Testing
 ------------------
 
+In order to test newly added code you must rebuild the distribution.
+
+```bash
+broccoli build dist
+```
+
 Adding fixtures with `defineFixture` tells ic-ajax to resolve the promise
 with the fixture matching a url instead of making a request. This allows
 you to test your app without creating fake servers with sinon, etc.
@@ -90,6 +96,7 @@ ic.ajax.request('api/v1/courses').then(function(result) {
 ```
 
 To test failure paths, set the `textStatus` to anything but `success`.
+
 
 Contributing
 ------------

--- a/dist/amd/main.js
+++ b/dist/amd/main.js
@@ -27,7 +27,7 @@ define(
     __exports__.request = request;__exports__["default"] = request;
 
     /*
-     * Same as `ajax` except it resolves an object with `{response, textStatus,
+     * Same as `request` except it resolves an object with `{response, textStatus,
      * jqXHR}`, useful if you need access to the jqXHR object for headers, etc.
      */
 
@@ -56,7 +56,7 @@ define(
      */
 
     function defineFixture(url, fixture) {
-      __fixtures__[url] = fixture;
+      __fixtures__[url] = JSON.parse(JSON.stringify(fixture));
     }
 
     __exports__.defineFixture = defineFixture;/*

--- a/dist/cjs/main.js
+++ b/dist/cjs/main.js
@@ -24,7 +24,7 @@ function request() {
 exports.request = request;exports["default"] = request;
 
 /*
- * Same as `ajax` except it resolves an object with `{response, textStatus,
+ * Same as `request` except it resolves an object with `{response, textStatus,
  * jqXHR}`, useful if you need access to the jqXHR object for headers, etc.
  */
 
@@ -53,7 +53,7 @@ exports.__fixtures__ = __fixtures__;
  */
 
 function defineFixture(url, fixture) {
-  __fixtures__[url] = fixture;
+  __fixtures__[url] = JSON.parse(JSON.stringify(fixture));
 }
 
 exports.defineFixture = defineFixture;/*

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -25,7 +25,7 @@ function request() {
 exports.request = request;exports["default"] = request;
 
 /*
- * Same as `ajax` except it resolves an object with `{response, textStatus,
+ * Same as `request` except it resolves an object with `{response, textStatus,
  * jqXHR}`, useful if you need access to the jqXHR object for headers, etc.
  */
 
@@ -54,7 +54,7 @@ exports.__fixtures__ = __fixtures__;
  */
 
 function defineFixture(url, fixture) {
-  __fixtures__[url] = fixture;
+  __fixtures__[url] = JSON.parse(JSON.stringify(fixture));
 }
 
 exports.defineFixture = defineFixture;/*

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -27,7 +27,7 @@ define("ic-ajax",
     __exports__.request = request;__exports__["default"] = request;
 
     /*
-     * Same as `ajax` except it resolves an object with `{response, textStatus,
+     * Same as `request` except it resolves an object with `{response, textStatus,
      * jqXHR}`, useful if you need access to the jqXHR object for headers, etc.
      */
 
@@ -56,7 +56,7 @@ define("ic-ajax",
      */
 
     function defineFixture(url, fixture) {
-      __fixtures__[url] = fixture;
+      __fixtures__[url] = JSON.parse(JSON.stringify(fixture));
     }
 
     __exports__.defineFixture = defineFixture;/*

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,7 +52,7 @@ export var __fixtures__ = {};
  */
 
 export function defineFixture(url, fixture) {
-  __fixtures__[url] = fixture;
+  __fixtures__[url] = JSON.parse(JSON.stringify(fixture));
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "broccoli": "^0.2.0",
     "broccoli-dist-es6-module": "^0.1.8",
+    "broccoli-cli": "*",
     "karma": "^0.10.9",
     "karma-chrome-launcher": "^0.1.2",
     "karma-firefox-launcher": "^0.1.3",
@@ -16,7 +17,7 @@
     "bower": "^1.2.8"
   },
   "scripts": {
-    "test": "node_modules/.bin/bower install ./node_modules/.bin/karma start --browsers Firefox --single-run"
+    "test": "node_modules/.bin/bower install && ./node_modules/.bin/karma start --browsers Firefox --single-run"
   },
   "repository": {
     "type": "git",

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -73,6 +73,24 @@ asyncTest('url and settings arguments', function() {
   server.restore();
 });
 
+asyncTest('the fixture is unaffected by external change', function() {
+  var resource = {foo: 'bar'};
+
+  ic.ajax.defineFixture('/foo', {
+    response: {resource: resource},
+    textStatus: 'success',
+    jqXHR: {}
+  });
+
+  resource.foo = 'baz';
+
+  ic.ajax.request('/foo').then(function(result) {
+      start();
+      deepEqual(result.resource.foo, 'bar');
+    }
+  )
+});
+
 test('throws if success or error callbacks are used', function() {
   var k = function() {};
   throws(function() {


### PR DESCRIPTION
This prevents any changes to fixtures data during the Ember run loop from affecting the original fixture.
