### PR TITLE
Store initializer is gone from ember-data

### DIFF
--- a/dist/amd/main.js
+++ b/dist/amd/main.js
@@ -129,7 +129,7 @@ define(
       Ember.onLoad('Ember.Application', function(Application){
         Application.initializer({
           name: 'ic-ajax_REST_Adapter',
-          after: 'store',
+          after: 'ember-data',
           initialize: function(container, application){
             if (request.OVERRIDE_REST_ADAPTER) {
               DS.RESTAdapter.reopen({

--- a/dist/cjs/main.js
+++ b/dist/cjs/main.js
@@ -126,7 +126,7 @@ if (typeof window.DS !== 'undefined'){
   Ember.onLoad('Ember.Application', function(Application){
     Application.initializer({
       name: 'ic-ajax_REST_Adapter',
-      after: 'store',
+      after: 'ember-data',
       initialize: function(container, application){
         if (request.OVERRIDE_REST_ADAPTER) {
           DS.RESTAdapter.reopen({

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -127,7 +127,7 @@ if (typeof window.DS !== 'undefined'){
   Ember.onLoad('Ember.Application', function(Application){
     Application.initializer({
       name: 'ic-ajax_REST_Adapter',
-      after: 'store',
+      after: 'ember-data',
       initialize: function(container, application){
         if (request.OVERRIDE_REST_ADAPTER) {
           DS.RESTAdapter.reopen({

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -129,7 +129,7 @@ define("ic-ajax",
       Ember.onLoad('Ember.Application', function(Application){
         Application.initializer({
           name: 'ic-ajax_REST_Adapter',
-          after: 'store',
+          after: 'ember-data',
           initialize: function(container, application){
             if (request.OVERRIDE_REST_ADAPTER) {
               DS.RESTAdapter.reopen({

--- a/lib/main.js
+++ b/lib/main.js
@@ -125,7 +125,7 @@ if (typeof window.DS !== 'undefined'){
   Ember.onLoad('Ember.Application', function(Application){
     Application.initializer({
       name: 'ic-ajax_REST_Adapter',
-      after: 'store',
+      after: 'ember-data',
       initialize: function(container, application){
         if (request.OVERRIDE_REST_ADAPTER) {
           DS.RESTAdapter.reopen({


### PR DESCRIPTION
The "store" initializer is gone, there is now only "ember-data":

https://github.com/emberjs/data/commit/fff110bc0c5ae17e815e8aad46e5c850e7ea5884#diff-f260869162b3be4d4d886975e77be4a6R14
