### PR TITLE
Ensure fixtures are returned asynchronously.

### DIFF
--- a/dist/amd/main.js
+++ b/dist/amd/main.js
@@ -77,9 +77,9 @@ define(
         var fixture = lookupFixture(settings.url);
         if (fixture) {
           if (fixture.textStatus === 'success' || fixture.textStatus == null) {
-            return Ember.run(null, resolve, fixture);
+            return Ember.run.later(null, resolve, fixture);
           } else {
-            return Ember.run(null, reject, fixture);
+            return Ember.run.later(null, reject, fixture);
           }
         }
         settings.success = makeSuccess(resolve);

--- a/dist/cjs/main.js
+++ b/dist/cjs/main.js
@@ -74,9 +74,9 @@ exports.lookupFixture = lookupFixture;function makePromise(settings) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {
-        return Ember.run(null, resolve, fixture);
+        return Ember.run.later(null, resolve, fixture);
       } else {
-        return Ember.run(null, reject, fixture);
+        return Ember.run.later(null, reject, fixture);
       }
     }
     settings.success = makeSuccess(resolve);

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -75,9 +75,9 @@ exports.lookupFixture = lookupFixture;function makePromise(settings) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {
-        return Ember.run(null, resolve, fixture);
+        return Ember.run.later(null, resolve, fixture);
       } else {
-        return Ember.run(null, reject, fixture);
+        return Ember.run.later(null, reject, fixture);
       }
     }
     settings.success = makeSuccess(resolve);

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -77,9 +77,9 @@ define("ic-ajax",
         var fixture = lookupFixture(settings.url);
         if (fixture) {
           if (fixture.textStatus === 'success' || fixture.textStatus == null) {
-            return Ember.run(null, resolve, fixture);
+            return Ember.run.later(null, resolve, fixture);
           } else {
-            return Ember.run(null, reject, fixture);
+            return Ember.run.later(null, reject, fixture);
           }
         }
         settings.success = makeSuccess(resolve);

--- a/lib/main.js
+++ b/lib/main.js
@@ -73,9 +73,9 @@ function makePromise(settings) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {
-        return Ember.run(null, resolve, fixture);
+        return Ember.run.later(null, resolve, fixture);
       } else {
-        return Ember.run(null, reject, fixture);
+        return Ember.run.later(null, reject, fixture);
       }
     }
     settings.success = makeSuccess(resolve);


### PR DESCRIPTION
Without this change fixtures are returned within the same run-loop (which is unlike a normal `$.ajax` request).

In some cases, this leads to passing tests but broken apps (because in the "real world" the `$.ajax` will be delayed by a small amount).
