### PR TITLE
Add onSend callback support for fixtures

### DIFF
--- a/dist/amd/main.js
+++ b/dist/amd/main.js
@@ -76,6 +76,9 @@ define(
       return new Ember.RSVP.Promise(function(resolve, reject) {
         var fixture = lookupFixture(settings.url);
         if (fixture) {
+          if (fixture.onSend) {
+            fixture.onSend(settings);
+          }
           if (fixture.textStatus === 'success' || fixture.textStatus == null) {
             return Ember.run.later(null, resolve, fixture);
           } else {

--- a/dist/cjs/main.js
+++ b/dist/cjs/main.js
@@ -73,6 +73,9 @@ exports.lookupFixture = lookupFixture;function makePromise(settings) {
   return new Ember.RSVP.Promise(function(resolve, reject) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
+      if (fixture.onSend) {
+        fixture.onSend(settings);
+      }
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {
         return Ember.run.later(null, resolve, fixture);
       } else {

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -74,6 +74,9 @@ exports.lookupFixture = lookupFixture;function makePromise(settings) {
   return new Ember.RSVP.Promise(function(resolve, reject) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
+      if (fixture.onSend) {
+        fixture.onSend(settings);
+      }
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {
         return Ember.run.later(null, resolve, fixture);
       } else {

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -76,6 +76,9 @@ define("ic-ajax",
       return new Ember.RSVP.Promise(function(resolve, reject) {
         var fixture = lookupFixture(settings.url);
         if (fixture) {
+          if (fixture.onSend) {
+            fixture.onSend(settings);
+          }
           if (fixture.textStatus === 'success' || fixture.textStatus == null) {
             return Ember.run.later(null, resolve, fixture);
           } else {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function(config) {
     frameworks: ['qunit'],
 
     files: [
-      'bower_components/jquery/jquery.js',
+      'bower_components/jquery/dist/jquery.js',
       'bower_components/handlebars/handlebars.js',
       'bower_components/ember/ember.js',
       'bower_components/sinon/index.js',

--- a/lib/main.js
+++ b/lib/main.js
@@ -72,6 +72,9 @@ function makePromise(settings) {
   return new Ember.RSVP.Promise(function(resolve, reject) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
+      if (fixture.onSend) {
+        fixture.onSend(settings);
+      }
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {
         return Ember.run.later(null, resolve, fixture);
       } else {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-qunit": "^0.1.1",
     "karma-script-launcher": "^0.1.0",
-    "qunitjs": "~1.12.0",
+    "qunitjs": "~1.14.0",
     "bower": "^1.3.5",
     "rf-release": "^0.1.0",
     "broccoli-cli": "0.0.1",

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -106,6 +106,38 @@ asyncTest('the fixture jqXHR survives the response copy', function() {
   )
 });
 
+asyncTest('adds onSend callback option to inspect xhr settings', function() {
+
+  var xhrRequests = [];
+
+  ic.ajax.defineFixture('/post', {
+    response: {},
+    textStatus: 'success',
+    jqXHR: {},
+    onSend: function(settings) {
+      xhrRequests.push(settings);
+    }
+  });
+
+  var req = {
+    type: "POST",
+    contentType: "application/json",
+    dataType: "json",
+    url: "/post",
+    data: JSON.stringify({
+      foo: "bar"
+    })
+  };
+
+  Ember.RSVP.all([ic.ajax.request(req), ic.ajax.request(req)])
+    .then(function() {
+      start();
+      equal(xhrRequests.length, 2);
+      var payload = JSON.parse(xhrRequests[0].data);
+      equal(payload.foo, "bar");
+    });
+});
+
 test('throws if success or error callbacks are used', function() {
   var k = function() {};
   throws(function() {


### PR DESCRIPTION
This is helpful to inspect xhr requests when doing integration tests but you don't have access to the actual request object directly.

I've done something similar with sinon.js using filters and inspecting the `onCreate/onSend` callbacks but this is a much cleaner implementation.

JS Bin: http://emberjs.jsbin.com/ricome/3/edit
