### PR TITLE
Send Error instances to reject()

### DIFF
--- a/dist/amd/main.js
+++ b/dist/amd/main.js
@@ -83,7 +83,7 @@ define(
           }
         }
         settings.success = makeSuccess(resolve);
-        settings.error = makeError(reject);
+        settings.error = makeError(settings, reject);
         Ember.$.ajax(settings);
       }, 'ic-ajax: ' + (settings.type || 'GET') + ' to ' + settings.url);
     };
@@ -116,13 +116,13 @@ define(
       }
     }
 
-    function makeError(reject) {
+    function makeError(settings, reject) {
       return function(jqXHR, textStatus, errorThrown) {
-        Ember.run(null, reject, {
-          jqXHR: jqXHR,
-          textStatus: textStatus,
-          errorThrown: errorThrown
-        });
+        var err = new Error((settings.type || 'GET') + ' ' + settings.url + ' ' + jqXHR.status + ' (' + errorThrown + ')');
+        err.jqXHR = jqXHR;
+        err.textStatus = textStatus;
+        err.errorThrown = errorThrown;
+        Ember.run(null, reject, err);
       };
     }
   });

--- a/dist/cjs/main.js
+++ b/dist/cjs/main.js
@@ -80,7 +80,7 @@ exports.lookupFixture = lookupFixture;function makePromise(settings) {
       }
     }
     settings.success = makeSuccess(resolve);
-    settings.error = makeError(reject);
+    settings.error = makeError(settings, reject);
     Ember.$.ajax(settings);
   }, 'ic-ajax: ' + (settings.type || 'GET') + ' to ' + settings.url);
 };
@@ -113,12 +113,12 @@ function makeSuccess(resolve) {
   }
 }
 
-function makeError(reject) {
+function makeError(settings, reject) {
   return function(jqXHR, textStatus, errorThrown) {
-    Ember.run(null, reject, {
-      jqXHR: jqXHR,
-      textStatus: textStatus,
-      errorThrown: errorThrown
-    });
+    var err = new Error((settings.type || 'GET') + ' ' + settings.url + ' ' + jqXHR.status + ' (' + errorThrown + ')');
+    err.jqXHR = jqXHR;
+    err.textStatus = textStatus;
+    err.errorThrown = errorThrown;
+    Ember.run(null, reject, err);
   };
 }

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -81,7 +81,7 @@ exports.lookupFixture = lookupFixture;function makePromise(settings) {
       }
     }
     settings.success = makeSuccess(resolve);
-    settings.error = makeError(reject);
+    settings.error = makeError(settings, reject);
     Ember.$.ajax(settings);
   }, 'ic-ajax: ' + (settings.type || 'GET') + ' to ' + settings.url);
 };
@@ -114,13 +114,13 @@ function makeSuccess(resolve) {
   }
 }
 
-function makeError(reject) {
+function makeError(settings, reject) {
   return function(jqXHR, textStatus, errorThrown) {
-    Ember.run(null, reject, {
-      jqXHR: jqXHR,
-      textStatus: textStatus,
-      errorThrown: errorThrown
-    });
+    var err = new Error((settings.type || 'GET') + ' ' + settings.url + ' ' + jqXHR.status + ' (' + errorThrown + ')');
+    err.jqXHR = jqXHR;
+    err.textStatus = textStatus;
+    err.errorThrown = errorThrown;
+    Ember.run(null, reject, err);
   };
 }
 },{}]},{},[1])

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -83,7 +83,7 @@ define("ic-ajax",
           }
         }
         settings.success = makeSuccess(resolve);
-        settings.error = makeError(reject);
+        settings.error = makeError(settings, reject);
         Ember.$.ajax(settings);
       }, 'ic-ajax: ' + (settings.type || 'GET') + ' to ' + settings.url);
     };
@@ -116,13 +116,13 @@ define("ic-ajax",
       }
     }
 
-    function makeError(reject) {
+    function makeError(settings, reject) {
       return function(jqXHR, textStatus, errorThrown) {
-        Ember.run(null, reject, {
-          jqXHR: jqXHR,
-          textStatus: textStatus,
-          errorThrown: errorThrown
-        });
+        var err = new Error((settings.type || 'GET') + ' ' + settings.url + ' ' + jqXHR.status + ' (' + errorThrown + ')');
+        err.jqXHR = jqXHR;
+        err.textStatus = textStatus;
+        err.errorThrown = errorThrown;
+        Ember.run(null, reject, err);
       };
     }
   });

--- a/lib/main.js
+++ b/lib/main.js
@@ -79,7 +79,7 @@ function makePromise(settings) {
       }
     }
     settings.success = makeSuccess(resolve);
-    settings.error = makeError(reject);
+    settings.error = makeError(settings, reject);
     Ember.$.ajax(settings);
   }, 'ic-ajax: ' + (settings.type || 'GET') + ' to ' + settings.url);
 };
@@ -112,12 +112,12 @@ function makeSuccess(resolve) {
   }
 }
 
-function makeError(reject) {
+function makeError(settings, reject) {
   return function(jqXHR, textStatus, errorThrown) {
-    Ember.run(null, reject, {
-      jqXHR: jqXHR,
-      textStatus: textStatus,
-      errorThrown: errorThrown
-    });
+    var err = new Error((settings.type || 'GET') + ' ' + settings.url + ' ' + jqXHR.status + ' (' + errorThrown + ')');
+    err.jqXHR = jqXHR;
+    err.textStatus = textStatus;
+    err.errorThrown = errorThrown;
+    Ember.run(null, reject, err);
   };
 }


### PR DESCRIPTION
Thanks for ic-ajax!

One small problem though. My company is also using a library that catches and reports unhandled RSVP errors, and I kept getting an [object Object] as a message with no other context information. We were able to track it down to ic-ajax sending an object to `reject()` instead of the recommended Error instance ([here](http://www.html5rocks.com/en/tutorials/es6/promises/#toc-api) and [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject)). This is reasonable because it helps debugging efforts and also because in practice, a lot of tools have come to expect this.

The fix aims to be minimally invasive by still providing `jqXHR`, `textStatus`, and `errorThrown` so existing code doesn't break, while still replacing a generic object with an Error instance.
